### PR TITLE
function_texi2html: replace only last occurrance of a tex expression by random string

### DIFF
--- a/inst/function_texi2html.m
+++ b/inst/function_texi2html.m
@@ -104,7 +104,10 @@ function function_texi2html (fcnname, pkgfcns, info)
         tex(j).str = {};
         tex(j).tex = text([tex_beg(j):tex_end(j)]);
         tex(j).rep = {symbols(randi (length (symbols), 1,length (symbols)))};
-        text = strrep (text, tex(j).tex, ["\n",tex(j).rep{:}]);
+        ## now replace only the last occurrance of tex(j).tex in text
+        text1 = text(1:tex_beg(j)-1);
+        text2 = text(tex_end(j)+1:end);
+        text = [text1, "\n", tex(j).rep{:}, text2];
         is_tex = 1;
         ## Keep tex literals
         tex_idx = strfind (tex(j).tex, "$$");


### PR DESCRIPTION
In the current version of _function_texi2html_, all occurrences of a multiply used tex expression are replaced by the random string which might turn the indices of remaining tex expressions invalid.