### PR TITLE
Allowing refs in the help texts to other package functions

### DIFF
--- a/inst/function_texi2html.m
+++ b/inst/function_texi2html.m
@@ -103,9 +103,11 @@ function function_texi2html (fcnname, pkgfcns, info)
     ## Add link to function's source code (if applicable)
     if (size (pkgfcns, 2) == 3)
       url = pkgfcns{fcn_idx, 3};
-      url_text = strcat (["<p><strong>Source Code: </strong>\n"], ...
-                         ["  <a href=""", url, """>", fcnname, "</a>\n</div>"]);
+      if (! isempty (url))
+        url_text = strcat (["<p><strong>Source Code: </strong>\n"], ...
+                           ["  <a href=""", url, """>", fcnname, "</a>\n</div>"]);
       fcn_text = strrep (fcn_text, "</div>", url_text);
+      endif
     endif
 
     ## Add DEMOS (if applicable)


### PR DESCRIPTION
This patch adds the possibility to refer to other package function by `@ref`, `@xref`, and `@pxref` in the help test already before `@seealso`. If the help text is related to a member of a legacy class, it is required to write, e.g. `@xref{@@class/member}` (with double `@@`) in order to avoid an error message in `makeinfo`.

The path also silences a warning on converting a numeric value into a char, if the url of single file sources are not found. This always might happen, if new functions are developped that are not yet in the main branch on Github. 